### PR TITLE
VS Code settings: Turned off automatic venv activation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.terminal.activateEnvInCurrentTerminal": true,
     "python.languageServer": "Pylance",
     "ruff.importStrategy": "fromEnvironment",
     "editor.formatOnSave": true,
@@ -22,4 +21,6 @@
     "python.analysis.inlayHints.functionReturnTypes": false,
     "python.analysis.inlayHints.pytestParameters": true,
     "python.terminal.executeInFileDir": true,
+    "python.terminal.activateEnvironment": false,
+    "python.terminal.activateEnvInCurrentTerminal": false,
 }


### PR DESCRIPTION
VS Code offers to automatically activate a virtual environment found in the workspace root folder. However, this feature is still buggy. It seems to only set the VIRTUAL_ENV environment variable, but does not call the activate script inside .venv/Scripts . This leads to inconsistent behaviour. pip, for instance, would install packages in the system python, although VS Code considers the venv activated.  
Until the automatic venv activation properly works in VS Code, I propose to explicitely turn it off in VS Code settings in each project.